### PR TITLE
Add admin debug tools functionality and related tests

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -56,6 +56,11 @@ def _svc():
     return current_app.config.get("LEAGUE_SERVICE")
 
 
+def _admin_debug_tools_enabled() -> bool:
+    """Random-score fill on /admin/enter — only when DEBUG is enabled."""
+    return os.environ.get("DEBUG", "false").strip().lower() in ("1", "true", "yes")
+
+
 def _forbidden_admin():
     return redirect(url_for("admin.admin_home", next=request.path))
 
@@ -226,14 +231,7 @@ def admin_enter_form():
         season_teams=all_teams,
         through_week=payload["week"],
     )
-    # Admin is PIN-gated; hide fill helper only when explicitly disabled (e.g. production).
-    hide_debug = os.environ.get("ADMIN_DEBUG_TOOLS", "").strip().lower() in (
-        "0",
-        "false",
-        "no",
-        "off",
-    )
-    show_debug_tools = not hide_debug
+    show_debug_tools = _admin_debug_tools_enabled()
     team_roster_names: list[str] = []
     if team:
         team_roster_names = [

--- a/tests/test_admin_form_parse.py
+++ b/tests/test_admin_form_parse.py
@@ -1,5 +1,10 @@
 """Tests for admin roster form parsing."""
-from app.admin_routes import _parse_teams_form, _players_for_team_index, _team_indices_from_form
+from app.admin_routes import (
+    _admin_debug_tools_enabled,
+    _parse_teams_form,
+    _players_for_team_index,
+    _team_indices_from_form,
+)
 
 
 class _FakeForm:
@@ -83,3 +88,10 @@ def test_parse_teams_form_with_picks(monkeypatch):
     assert len(teams) == 2
     assert teams[0]["players"] == ["Alice"]
     assert teams[1]["players"] == ["Carl"]
+
+
+def test_admin_debug_tools_follows_debug(monkeypatch):
+    monkeypatch.setenv("DEBUG", "false")
+    assert _admin_debug_tools_enabled() is False
+    monkeypatch.setenv("DEBUG", "true")
+    assert _admin_debug_tools_enabled() is True


### PR DESCRIPTION
Introduce a new function to determine if admin debug tools are enabled based on the DEBUG environment variable. Update the admin enter form to utilize this function for showing debug tools. Add tests to verify the behavior of the new debug tools functionality under different DEBUG settings.